### PR TITLE
Add support for PHP8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
+        "php": ">=7.4|>=8.0",
         "ext-soap": "*"
     },
     "require-dev": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,4 +19,3 @@ parameters:
         - '#Method [A-Za-z\\]+::[a-zA-Z0-9\\_]+\(\) has a nullable return type declaration.#'
         - '#Constructor in [A-Za-z\\]+ has parameter [\$A-Za-z]+ with default value.#'
         - '#Language construct isset\(\) should not be used.#'
-        - '#Call to an undefined method SoapClient::checkVat\(\).#'


### PR DESCRIPTION
* The package already supports PHP8.0, just the composer requirement had to be updated.
* Due to a new version of PHPStan, a previously (manually) ignored error, is now no longer relevant. Removed it.