### PR TITLE
Modify version constraints for dev-dependencies, make them less strict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,13 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "phpstan/phpstan": "^0.12.71",
+        "phpstan/phpstan": "^0.12",
         "friendsofphp/php-cs-fixer": "^2.18",
         "uptimeproject/php-cs-fixer-config": "^1.1",
-        "phpstan/phpstan-strict-rules": "^0.12.9",
-        "phpstan/phpstan-deprecation-rules": "^0.12.6",
-        "phpstan/phpstan-phpunit": "^0.12.17",
-        "ergebnis/phpstan-rules": "^0.15.3"
+        "phpstan/phpstan-strict-rules": "^0.12",
+        "phpstan/phpstan-deprecation-rules": "^0.12",
+        "phpstan/phpstan-phpunit": "^0.12",
+        "ergebnis/phpstan-rules": "^0.15"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR makes the version constraints for dev-dependencies less strict. This way, we stay more up-to-date.

We do take a risk that a minor version bump will break the project automation, but that can probably be fixed quickly.