### PR TITLE
prevent public wsdl loading in constructors

### DIFF
--- a/src/VatNumbers/ViesClient.php
+++ b/src/VatNumbers/ViesClient.php
@@ -10,11 +10,11 @@ final class ViesClient implements ValidatesVatNumbers
 {
     const WSDL = 'https://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl';
 
-    private SoapClient $client;
+    private ?SoapClient $client;
 
     public function __construct(?SoapClient $client = null)
     {
-        $this->client = $client ?? new SoapClient(self::WSDL);
+        $this->client = $client;
     }
 
     public function verifyVatNumber(string $vatNumber, string $countryCode): bool
@@ -25,7 +25,7 @@ final class ViesClient implements ValidatesVatNumbers
         ];
 
         try {
-            $response = $this->client->checkVat($params);
+            $response = $this->getClient()->checkVat($params);
 
             return $response->valid;
         } catch (SoapFault $fault) {
@@ -34,5 +34,14 @@ final class ViesClient implements ValidatesVatNumbers
                 ['checkVat' => $params],
             );
         }
+    }
+
+    public function getClient(): SoapClient
+    {
+        if (! $this->client instanceof SoapClient) {
+            $this->client = new SoapClient(self::WSDL);
+        }
+
+        return $this->client;
     }
 }

--- a/src/VatRates/TaxesEuropeDatabaseClient.php
+++ b/src/VatRates/TaxesEuropeDatabaseClient.php
@@ -15,11 +15,11 @@ final class TaxesEuropeDatabaseClient implements ResolvesVatRates
     const RATE_TYPE_STANDARD = 'STANDARD';
     const RATE_VALUE_TYPE_DEFAULT = 'DEFAULT';
 
-    private SoapClient $client;
+    private ?SoapClient $client;
 
     public function __construct(?SoapClient $client = null)
     {
-        $this->client = $client ?? new SoapClient(self::WSDL);
+        $this->client = $client;
     }
 
     /**
@@ -86,7 +86,7 @@ final class TaxesEuropeDatabaseClient implements ResolvesVatRates
     private function call(string $call, array $params): ?object
     {
         try {
-            $response = $this->client->__soapCall($call, $params);
+            $response = $this->getClient()->__soapCall($call, $params);
             if (! is_object($response)) {
                 return null;
             }
@@ -97,5 +97,14 @@ final class TaxesEuropeDatabaseClient implements ResolvesVatRates
                 $params
             );
         }
+    }
+
+    private function getClient(): SoapClient
+    {
+        if (! $this->client instanceof SoapClient) {
+            $this->client = new SoapClient(self::WSDL);
+        }
+
+        return $this->client;
     }
 }


### PR DESCRIPTION
The current constructors initialize the SoapClient with WSDL public url, this will directly try to load that WSDL. In the end this can result in a request for the WSDL on every request/process the application runs. As these EU services are known to be down quite often this can cause problems in total unrelated situations (deployments, builds, unrelated processes in the application implementing this package).